### PR TITLE
Update extensions versions to latest version

### DIFF
--- a/src/extensions.ts
+++ b/src/extensions.ts
@@ -2,15 +2,15 @@ import type { ExtensionReference } from "./index";
 
 export const EMBER_INSPECTOR: ExtensionReference = {
   id: "bmdblncegkenkacieihfhpjfppoconhi",
-  version: "4.9.1",
+  version: "4.13.1",
 };
 export const REACT_DEVELOPER_TOOLS: ExtensionReference = {
   id: "fmkadmapgofadopljbjfkapdkoienihi",
-  version: "4.27.3",
+  version: "6.1.5",
 };
 export const BACKBONE_DEBUGGER: ExtensionReference = {
   id: "bhljhndlimiafopmmhjlgfpnnchjjbhd",
-  version: "0.4.1",
+  version: "0.5.0",
 };
 export const JQUERY_DEBUGGER: ExtensionReference = {
   id: "dbhhnnnpaeobfddmlalhnehgclcmjimi",
@@ -18,21 +18,21 @@ export const JQUERY_DEBUGGER: ExtensionReference = {
 };
 export const ANGULAR_DEVTOOLS: ExtensionReference = {
   id: "ienfalfjdbdpebioblfackkekamfmbnh",
-  version: "1.0.7",
+  version: "1.0.39",
 };
 export const VUEJS_DEVTOOLS: ExtensionReference = {
   id: "nhdogjmejiglipccpnnnanhbledajbpd",
-  version: "6.5.0",
+  version: "7.7.7",
 };
 export const REDUX_DEVTOOLS: ExtensionReference = {
   id: "lmhkpmbekcpmknklioeibfkpmmfibljd",
-  version: "3.0.19",
+  version: "3.2.10",
 };
 export const APOLLO_DEVELOPER_TOOLS: ExtensionReference = {
   id: "jdkknkkbebbapilgoeccciglkfbmbnfm",
-  version: "4.1.4",
+  version: "4.19.13",
 };
 export const MOBX_DEVTOOLS: ExtensionReference = {
   id: "pfgnfdagidkfgccljigdamigbcnndkod",
-  version: "0.9.26",
+  version: "0.9.31",
 };


### PR DESCRIPTION
This updates extension versions to the latest version found in the chrome web store.

https://chromewebstore.google.com/detail/ember-inspector/{extension-id-here}


This fixes deprecation warnings in console:

```
ExtensionLoadWarning: Warnings loading extension at /Users/nytrm/Library/Application Support/Electron/chrome-extensions/fmkadmapgofadopljbjfkapdkoienihi:
  Manifest version 2 is deprecated, and support will be removed in 2025. See https://developer.chrome.com/docs/extensions/develop/migrate/mv2-deprecation-timeline for details.
```